### PR TITLE
Implement basic Firebase search service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/cookfluencerbackend/config/FirebaseConfig.java
+++ b/src/main/java/com/example/cookfluencerbackend/config/FirebaseConfig.java
@@ -1,0 +1,35 @@
+package com.example.cookfluencerbackend.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.credentials}")
+    private String credentialsPath;
+
+    @Value("${firebase.database-url}")
+    private String databaseUrl;
+
+    @PostConstruct
+    public void init() throws IOException {
+        FileInputStream serviceAccount = new FileInputStream(credentialsPath);
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .setDatabaseUrl(databaseUrl)
+                .build();
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp.initializeApp(options);
+        }
+    }
+}

--- a/src/main/java/com/example/cookfluencerbackend/controller/SearchController.java
+++ b/src/main/java/com/example/cookfluencerbackend/controller/SearchController.java
@@ -1,0 +1,30 @@
+package com.example.cookfluencerbackend.controller;
+
+import com.example.cookfluencerbackend.service.FirebaseSearchService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class SearchController {
+
+    private final FirebaseSearchService searchService;
+
+    @Value("${firebase.collection}")
+    private String collection;
+
+    @Value("${firebase.search-field}")
+    private String searchField;
+
+    public SearchController(FirebaseSearchService searchService) {
+        this.searchService = searchService;
+    }
+
+    @GetMapping("/search")
+    public List<String> search(@RequestParam("q") String query) throws Exception {
+        return searchService.search(collection, searchField, query);
+    }
+}

--- a/src/main/java/com/example/cookfluencerbackend/service/FirebaseSearchService.java
+++ b/src/main/java/com/example/cookfluencerbackend/service/FirebaseSearchService.java
@@ -1,0 +1,24 @@
+package com.example.cookfluencerbackend.service;
+
+import com.google.cloud.firestore.Firestore;
+import com.google.firebase.cloud.FirestoreClient;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class FirebaseSearchService {
+
+    public List<String> search(String collection, String field, String keyword) throws Exception {
+        Firestore db = FirestoreClient.getFirestore();
+        return db.collection(collection)
+                .get()
+                .get()
+                .getDocuments()
+                .stream()
+                .map(doc -> doc.getString(field))
+                .filter(value -> value != null && value.toLowerCase().contains(keyword.toLowerCase()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=Cookfluencer-backend
+firebase.credentials=/path/to/serviceAccountKey.json
+firebase.database-url=https://your-project.firebaseio.com
+firebase.collection=items
+firebase.search-field=name


### PR DESCRIPTION
## Summary
- add Firebase Admin dependency
- configure Firebase initialization
- provide simple service for reading Firestore documents
- expose a `/search` endpoint
- document Firebase properties

## Testing
- `gradle test --no-daemon` *(fails: Plugin resolution requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_68501d41da28832b83470466117dc0f4